### PR TITLE
Optional lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.26] - 2018-06-01
+### Added
+- Optional lookup
+
 
 ## [0.0.25] - 2018-04-24
 ### Fixed

--- a/gcdt_lookups/lookups.py
+++ b/gcdt_lookups/lookups.py
@@ -169,6 +169,9 @@ def _resolve_single_value(awsclient, value, stacks, lookups, is_yugen=False):
                         raise Exception('Stack \'%s\' does not exist.' % key[0])
                     if len(key) == 2:
                         # lookup:stack:<stack-name>:<output-name>
+                        if (key[1] not in stacks[key[0]] and optional_lookup):
+                            return ''
+
                         return stacks[key[0]][key[1]]
                     else:
                         log.warn('lookup format not as expected for \'%s\'', value)

--- a/gcdt_lookups/lookups.py
+++ b/gcdt_lookups/lookups.py
@@ -138,7 +138,7 @@ def _get_lookup_details(value):
     key = splits[2:]
 
     # support for non-mandatory lookups that will be replaced with empty value
-    if key[-1] == 'optional' and len(key) > 2:
+    if len(key) > 0 and key[-1] == 'optional' and len(key) > 2:
         optional_lookup = True
         key = key[:-1]
 

--- a/tests/test_lookups.py
+++ b/tests/test_lookups.py
@@ -53,8 +53,30 @@ def test_stack_lookup_value(mock_stack_exists, mock_get_outputs_for_stack):
            'arn:aws:lambda:eu-west-1:1122233:function:dp-preprod-lambdaEC2Basics-12'
 
 @mock.patch('gcdt_lookups.lookups.get_outputs_for_stack')
+@mock.patch('gcdt_lookups.lookups.stack_exists', return_value=True)
+def test_stack_lookup_optional_value_no_output(mock_stack_exists, mock_get_outputs_for_stack):
+    mock_get_outputs_for_stack.return_value = {
+        'AnotherValue':
+            'arn:aws:lambda:eu-west-1:1122233:function:dp-preprod-lambdaEC2Basics-12',
+    }
+    # sample from data-platform, operations
+    context = {
+        '_awsclient': 'my_awsclient',
+        'tool': 'ramuda'
+    }
+
+    config = {
+        'LambdaLookupARN': 'lookup:stack:dp-preprod:EC2BasicsLambdaArn:optional'
+    }
+    _resolve_lookups(context, config, ['stack'])
+    mock_get_outputs_for_stack.assert_called_once_with(
+        'my_awsclient', 'dp-preprod', None)
+
+    assert config.get('LambdaLookupARN') == ''
+
+@mock.patch('gcdt_lookups.lookups.get_outputs_for_stack')
 @mock.patch('gcdt_lookups.lookups.stack_exists', return_value=False)
-def test_stack_lookup_optional_value(mock_stack_exists, mock_get_outputs_for_stack):
+def test_stack_lookup_optional_value_no_stack(mock_stack_exists, mock_get_outputs_for_stack):
     # sample from data-platform, operations
     context = {
         '_awsclient': 'my_awsclient',

--- a/tests/test_lookups.py
+++ b/tests/test_lookups.py
@@ -52,6 +52,28 @@ def test_stack_lookup_value(mock_stack_exists, mock_get_outputs_for_stack):
     assert config.get('LambdaLookupARN') == \
            'arn:aws:lambda:eu-west-1:1122233:function:dp-preprod-lambdaEC2Basics-12'
 
+@mock.patch('gcdt_lookups.lookups.get_outputs_for_stack')
+@mock.patch('gcdt_lookups.lookups.stack_exists', return_value=False)
+def test_stack_lookup_optional_value(mock_stack_exists, mock_get_outputs_for_stack):
+    mock_get_outputs_for_stack.return_value = {
+        'EC2BasicsLambdaArn':
+            'arn:aws:lambda:eu-west-1:1122233:function:dp-preprod-lambdaEC2Basics-12',
+    }
+    # sample from data-platform, operations
+    context = {
+        '_awsclient': 'my_awsclient',
+        'tool': 'ramuda'
+    }
+
+    config = {
+        'LambdaLookupARN': 'lookup:stack:non-existing-stack:NonExistingValue:optional'
+    }
+    _resolve_lookups(context, config, ['stack'])
+    mock_get_outputs_for_stack.assert_called_once_with(
+        'my_awsclient', 'dp-preprod', None)
+
+    assert config.get('LambdaLookupARN') == ''
+
 
 @mock.patch('gcdt_lookups.lookups.get_outputs_for_stack')
 @mock.patch('gcdt_lookups.lookups.stack_exists', return_value=True)

--- a/tests/test_lookups.py
+++ b/tests/test_lookups.py
@@ -55,10 +55,6 @@ def test_stack_lookup_value(mock_stack_exists, mock_get_outputs_for_stack):
 @mock.patch('gcdt_lookups.lookups.get_outputs_for_stack')
 @mock.patch('gcdt_lookups.lookups.stack_exists', return_value=False)
 def test_stack_lookup_optional_value(mock_stack_exists, mock_get_outputs_for_stack):
-    mock_get_outputs_for_stack.return_value = {
-        'EC2BasicsLambdaArn':
-            'arn:aws:lambda:eu-west-1:1122233:function:dp-preprod-lambdaEC2Basics-12',
-    }
     # sample from data-platform, operations
     context = {
         '_awsclient': 'my_awsclient',
@@ -69,8 +65,6 @@ def test_stack_lookup_optional_value(mock_stack_exists, mock_get_outputs_for_sta
         'LambdaLookupARN': 'lookup:stack:non-existing-stack:NonExistingValue:optional'
     }
     _resolve_lookups(context, config, ['stack'])
-    mock_get_outputs_for_stack.assert_called_once_with(
-        'my_awsclient', 'dp-preprod', None)
 
     assert config.get('LambdaLookupARN') == ''
 


### PR DESCRIPTION
## Adding optional lookups
In use-cases when looked-up stack is not present, there should be an option to silently ignore such errors.

lookup:stack:<StackName>:<OutputValue>:optional - will return empty string if there are no stack, instead of Exception for lookup:stack:<StackName>:<OutputValue>